### PR TITLE
feat: add color-coded labels for review time in GitHub Action

### DIFF
--- a/.github/workflows/time-to-review.yml
+++ b/.github/workflows/time-to-review.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   time-to-review:

--- a/README.md
+++ b/README.md
@@ -57,12 +57,17 @@ jobs:
 
 The action will add one of the following labels to your pull request:
 
-- `1 min review`
-- `5 min review`
-- `10 min review`
-- `15 min review`
-- `20 min review`
-- `30 min review`
+- `1 min review` (🟢 Green)
+- `5 min review` (🟡 Yellow)
+- `10 min review` (🟡 Yellow)
+- `15 min review` (🔴 Red)
+- `20 min review` (🔴 Red)
+- `30 min review` (🔴 Red)
+
+The labels are color-coded for quick visual priority assessment:
+- Green: Quick reviews (1 minute)
+- Yellow: Medium reviews (5-10 minutes)
+- Red: Longer reviews (>10 minutes)
 
 ## License
 


### PR DESCRIPTION
This pull request introduces color-coded labels for pull request review times, enhancing visual prioritization and ensuring label consistency in the repository. The key changes include updates to the label descriptions in the documentation and the implementation of logic to assign and manage label colors dynamically in the code.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R70): Updated the description of review time labels to include their corresponding colors (Green, Yellow, Red) and added a visual priority guide for quick assessment.

### Code Enhancements:
* `time-to-review.js`: 
  * Updated the `run` function to calculate and log the label color alongside the review time and label name.
  * Added a new `getLabelColor` function to determine the appropriate color for a review time label based on the estimated review time.
  * Introduced an `ensureLabelExists` function to verify the existence of a label in the repository, updating its color if it exists or creating it if it does not. This ensures consistency in label management.